### PR TITLE
Add handleOnlyControl option

### DIFF
--- a/src/comparison-slider.ts
+++ b/src/comparison-slider.ts
@@ -9,6 +9,7 @@ interface Options {
 	$handle?: HTMLElement | string;
 	auto?: boolean;
 	autoArea?: HTMLElement;
+	handleOnlyControl?: boolean;
 }
 
 export default class ComparisonSlider {
@@ -78,7 +79,21 @@ export default class ComparisonSlider {
 		function onMouseDown( event: MouseEvent ) {
 
 			event.preventDefault();
-			startDragging( event );
+			const { target } = event;
+			const { handleOnlyControl, $handle } = options
+
+			if (handleOnlyControl) {
+				const handle = $handle || '.ComparisonSlider__Handle'
+
+				if (
+					target !== null
+					&& (<HTMLElement> target).matches(handle)
+				) {
+					startDragging( event );
+				}
+			} else {
+				startDragging( event );
+			}
 
 		}
 


### PR DESCRIPTION
The handleOnlyControl option disabled the slider movement by clicking
anywhere on the surface. If this boolean option is set to `true`, only
the handle itself can be used to move the slider.